### PR TITLE
issue template for new features added

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,44 @@
+---
+name: 'Feature'
+about: 'Use this template to open issues for new features'
+title: '[FEATURE NAME]'
+labels: 'Type: Enhancement, Status: To Do'
+assignees: ''
+---
+
+Is your proposal related to a problem?
+--------------------------------------
+<!--
+  Provide a clear and concise description of what the problem is.
+  For example, "I'm always frustrated when..."
+-->
+
+(Write your answer here.)
+
+Describe the solution you'd like
+--------------------------------
+
+<!--
+  Provide a clear and concise description of what you want to happen.
+-->
+
+(Describe your proposed solution here.)
+
+Describe alternatives you've considered
+---------------------------------------
+
+<!--
+  Let us know about other solutions you've tried or researched.
+-->
+
+(Write your answer here.)
+
+Additional context
+------------------
+
+<!--
+  Is there anything else you can add about the proposal?
+  You might want to link to related issues here, if you haven't already.
+-->
+
+(Write your answer here.)


### PR DESCRIPTION
Issue templates are useful for fast and consistent issue opening. In this pull request, the template for feature is added to the repository. The base of the template could be found at this link: https://github.com/wagtail/wagtail/issues/5560