### PR TITLE
issue templates for bugs added

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,46 @@
+---
+name: 'Bug'
+about: 'Use this template to open issues for new bugs'
+title: '[BUG]'
+labels: 'Type: Bug, Status: To Do'
+assignees: ''
+---
+
+
+What are the steps to reproduce this issue?
+-------------------------------------------
+(Write your answer here.)
+<!--
+1. …
+2. …
+3. …
+-->
+
+What happens?
+-------------
+(Write your answer here.)
+
+What were you expecting to happen?
+----------------------------------
+(Write your answer here.)
+
+Any logs, error output, etc?
+----------------------------
+<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->
+
+(Write your answer here.)
+
+Any other comments?
+-------------------
+(Write your answer here.)
+
+What versions of software are you using?
+----------------------------------------
+(Write your answer here.)
+<!--
+**Operating System:** …
+
+**Toolchain Version:** …
+
+**SDK Version:** …
+-->


### PR DESCRIPTION
Issue templates are useful for fast and consistent issue opening. In this pull request, the template for bugs is added to the repository. The base of the template could be found at this link: https://github.com/theos/theos/blob/master/.github/ISSUE_TEMPLATE.md