### PR TITLE
issue templates for wiki added

### DIFF
--- a/.github/ISSUE_TEMPLATE/wiki.md
+++ b/.github/ISSUE_TEMPLATE/wiki.md
@@ -1,0 +1,37 @@
+---
+name: 'Wiki'
+about: 'Use this template to open issues for wiki updates'
+title: '[WIKI UPDATE]'
+labels: 'Type: Wiki, Status: To Do'
+assignees: ''
+---
+
+
+Why is this wiki update necessary, what is the problem?
+--------------------------------------
+<!--
+  Provide a clear and concise description of what the problem is.
+  For example, "I'm always frustrated when..."
+-->
+
+(Write your answer here.)
+
+Describe the solution you'd like
+--------------------------------
+
+<!--
+  Provide a clear and concise description of what you want to happen.
+-->
+
+(Describe your proposed solution here.)
+
+Additional context and references
+---------------------------------
+
+<!--
+  Is there anything else you can add about the proposal?
+  You might want to link to related issues here, if you haven't already.
+  Also, you can give reference to wiki page link you want to change.
+-->
+
+(Write your answer here.)


### PR DESCRIPTION
Issue templates are useful for fast and consistent issue opening. In this pull request, the template for wiki is added to the repository. The base of the template could be found at these links: https://github.com/theos/theos/blob/master/.github/ISSUE_TEMPLATE.md
https://github.com/wagtail/wagtail/issues/5560