### PR TITLE
HF- Change email to username in login error message

### DIFF
--- a/Columbus/frontend/src/components/Forms/LoginForm/LoginForm.js
+++ b/Columbus/frontend/src/components/Forms/LoginForm/LoginForm.js
@@ -57,7 +57,7 @@ const LoginForm = ({ handleClose, showError}) => {
         }
         /> 
         <div>
-        {showError ? <p className={classes.error}>Email or Password is wrong!</p> : null}
+        {showError ? <p className={classes.error}>Username or Password is wrong!</p> : null}
         <Button 
         type = "submit"
         variant = "contained"


### PR DESCRIPTION
Proposed changes
----------------
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
The error message in frontend says the 'Email or password is wrong' rather than 'Username or password is wrong'

Types of changes
----------------

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
