### PR TITLE
hot fix for tuple object without comma

### DIFF
--- a/Columbus/backend/src/settings.py
+++ b/Columbus/backend/src/settings.py
@@ -168,7 +168,6 @@ EMAIL_HOST_USER = 'junkcolumbus@gmail.com'
 EMAIL_HOST_PASSWORD = 'junk_Columbus_451'
 
 REST_FRAMEWORK = {'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
-                  'DEFAULT_AUTHENTICATION_CLASSES': (
-                      'rest_framework.authentication.TokenAuthentication',
-                      'rest_framework.authentication.SessionAuthentication')
+                  'DEFAULT_AUTHENTICATION_CLASSES': ['rest_framework.authentication.TokenAuthentication']
+
                   }


### PR DESCRIPTION
tuple object with one element without comma is considered as string. Fixed 