### PR TITLE
CF-31 API Authentication Header Not Sent After Going to Home Page

### DIFF
--- a/Columbus/frontend/src/App.js
+++ b/Columbus/frontend/src/App.js
@@ -8,6 +8,7 @@ import CreatePostPage from "./pages/CreatePostPage";
 import {Snackbar, IconButton } from "@material-ui/core";
 import CloseIcon from "@material-ui/icons/Close";
 import Profile from "./pages/Profile"
+import {API_INSTANCE} from './config/api';
 
 function App() {
   const [Authenticated, setAuthenticated] = useState(false)
@@ -18,6 +19,9 @@ function App() {
 
   useEffect(() => {
     setAuthenticated(!!localStorage.getItem("jwtToken"));
+    if(!!localStorage.getItem("jwtToken")){
+      API_INSTANCE.defaults.headers.common['Authorization'] = localStorage.getItem("jwtToken");
+    }
     document.title="Columbus"
   }, [])
 


### PR DESCRIPTION
Proposed changes
----------------
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The Authentication header set after login and removed after logging out. The error about not sending the request is now fixed.

Types of changes
----------------

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

Checklist
---------

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

Further comments
----------------
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
(Write your answer here.)
