### PR TITLE
date search functionality added to combined search

### DIFF
--- a/Columbus/backend/search/serializers.py
+++ b/Columbus/backend/search/serializers.py
@@ -75,6 +75,18 @@ class SearchSerializer(serializers.ModelSerializer):
     max_longitude = serializers.FloatField()
     min_latitude = serializers.FloatField()
     min_longitude = serializers.FloatField()
+    search_date_type = serializers.CharField()
+    search_date = serializers.IntegerField()
+    search_year_start = serializers.IntegerField()
+    search_month_start = serializers.IntegerField()
+    search_day_start = serializers.IntegerField()
+    search_hour_start = serializers.IntegerField()
+    search_minute_start = serializers.IntegerField()
+    search_year_end = serializers.IntegerField()
+    search_month_end = serializers.IntegerField()
+    search_day_end = serializers.IntegerField()
+    search_hour_end = serializers.IntegerField()
+    search_minute_end = serializers.IntegerField()
     class Meta:
         model = Story
-        fields = ['username', 'search_text', 'page_number', 'page_size', 'query_latitude', 'query_longitude', 'query_distance', 'location_text', 'max_latitude', 'max_longitude', 'min_latitude', 'min_longitude']
+        fields = ['username', 'search_text', 'page_number', 'page_size', 'query_latitude', 'query_longitude', 'query_distance', 'location_text', 'max_latitude', 'max_longitude', 'min_latitude', 'min_longitude', 'search_date_type', 'search_date', 'search_year_start', 'search_month_start', 'search_day_start', 'search_hour_start', 'search_minute_start', 'search_year_end', 'search_month_end', 'search_day_end', 'search_hour_end', 'search_minute_end']


### PR DESCRIPTION
Proposed changes
----------------
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
The date search functionality has been added to the combined search. Users could search with 3 different types. Decade and century searches look only for their corresponding such as decade and century. The specific search could have a start and end time. If there is an overlap between query times and story times, those stories are returned. The specificity could be changed from year to minute.

Types of changes
----------------

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
